### PR TITLE
Ensure files_to_ignore is passed as a single arg

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -22,7 +22,7 @@ main() {
   export GPT_MODEL="$gpt_model_name"
 
   local -r pr_number=$(github::get_pr_number)
-  local -r commit_diff=$(github::get_commit_diff "$pr_number" "$files_to_ignore")
+  local -r commit_diff=$(github::get_commit_diff "$pr_number" "${files_to_ignore[*]}")
 
   if [ -z "$commit_diff" ]; then
     utils::log_info "Nothing in the commit diff."


### PR DESCRIPTION
As the title implies, this ensures that the argument is passed as a single string value that is whitespace delimited. 