### PR TITLE
feat: add GitLab provider support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,40 @@
+name: Publish Docker Image
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: integral-healthcare/robin-ai-reviewer
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7.1.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/robin.yml
+++ b/.github/workflows/robin.yml
@@ -19,7 +19,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_PROVIDER: claude
           AI_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
-          AI_MODEL: claude-3-sonnet-20240229
+          AI_MODEL: claude-3-7-sonnet-20250219
           files_to_ignore: |
             "README.md"
             "assets/*"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <img src="/assets/robin.png" alt="Robin watercolor image" style="width: 350px;"/>
 </div>
 
-Named after Batman's assistant, Robin AI is an open source Github action that automatically reviews pull requests using AI models from OpenAI (GPT) or Anthropic (Claude). It analyzes your code changes and provides:
+Named after Batman's assistant, Robin AI is an open source GitHub Action and GitLab CI job that automatically reviews pull requests and merge requests using AI models from OpenAI (GPT) or Anthropic (Claude). It analyzes your code changes and provides:
 - A quality score (0-100)
 - Actionable improvement suggestions
 - Sample code snippets for better implementation
@@ -27,12 +27,15 @@ Named after Batman's assistant, Robin AI is an open source Github action that au
 - [License](#license)
 
 ## Prerequisites
-- A GitHub repository with pull request workflows
+- A GitHub repository with pull request workflows or a GitLab project with merge request pipelines
 - An API key for your chosen AI provider:
   - **OpenAI**: [Get an API key here](https://platform.openai.com/account/api-keys)
   - **Claude (Anthropic)**: [Get an API key here](https://console.anthropic.com/settings/keys)
 
 ## Installation
+
+### GitHub Actions
+
 1. In your Github repository, navigate to the "Actions" tab
 2. Click "New workflow"
 3. Choose "Set up a workflow yourself"
@@ -93,7 +96,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_PROVIDER: claude
           AI_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
-          AI_MODEL: claude-3-sonnet-20240229
+          AI_MODEL: claude-3-7-sonnet-20250219
           files_to_ignore: |
             "README.md"
             "assets/*"
@@ -136,9 +139,33 @@ jobs:
    - For Claude: Create a secret named `CLAUDE_API_KEY`
    - Paste your API key as the value
 
+### GitLab CI
+
+Robin AI runs in GitLab CI from the published Docker image. Add a project or personal access token with the `api` scope as a CI/CD variable named `GITLAB_TOKEN`, plus the API key for your selected AI provider.
+
+```yml
+robin_ai_review:
+  image:
+    name: ghcr.io/integral-healthcare/robin-ai-reviewer:latest
+    entrypoint: [""]
+  stage: test
+  script:
+    - >
+      /entrypoint.sh
+      --git_provider=gitlab
+      --git_token="${GITLAB_TOKEN}"
+      --ai_provider=openai
+      --ai_api_key="${OPEN_AI_API_KEY}"
+      --ai_model=o4-mini
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+```
+
+For Claude, set `--ai_provider=claude`, pass your Claude API key to `--ai_api_key`, and set `--ai_model` to the Claude model you want to use.
+
 ## Configuration
 
-### Parameters (Recommended)
+### GitHub Action Parameters
 | Name | Required | Default | Description |
 |------|----------|---------|-------------|
 | `GITHUB_TOKEN` | Yes | Auto-supplied | GitHub token for API access |
@@ -146,6 +173,16 @@ jobs:
 | `AI_API_KEY` | Yes | N/A | API key for the selected AI provider |
 | `AI_MODEL` | No | Provider-specific | AI model to use (see supported models below) |
 | `github_api_url` | No | `https://api.github.com` | GitHub API URL (for enterprise) |
+| `files_to_ignore` | No | (empty) | Files to exclude from review |
+
+### Docker and GitLab Arguments
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `git_provider` | No | `github` | Git provider to review (`github` or `gitlab`) |
+| `git_token` | Yes for GitLab | N/A | GitLab token with the `api` scope |
+| `ai_provider` | No | `openai` | AI provider to use (`openai` or `claude`) |
+| `ai_api_key` | Yes | N/A | API key for the selected AI provider |
+| `ai_model` | No | Provider-specific | AI model to use |
 | `files_to_ignore` | No | (empty) | Files to exclude from review |
 
 ### Legacy Parameters (Deprecated but still supported)
@@ -156,7 +193,7 @@ jobs:
 
 ## Usage
 
-When Robin AI runs, it will post a comment on the pull request with its score out of 100, suggested improvements, and sample code for improvement. You can use this information to improve the quality of your code and make your pull requests more likely to be accepted.
+When Robin AI runs, it will post a comment on the pull request or merge request with its score out of 100, suggested improvements, and sample code for improvement. You can use this information to improve the quality of your code and make your pull requests more likely to be accepted.
 
 ## Example Output
 When Robin AI reviews your pull request, you'll see a comment like this:

--- a/src/github.sh
+++ b/src/github.sh
@@ -25,7 +25,7 @@ github::get_commit_diff() {
 
       [[ "$status" == "removed" ]] && continue
 
-      if ! github::should_ignore_file "$filename" "$files_to_ignore"; then
+      if ! utils::should_ignore_file "$filename" "$files_to_ignore"; then
         diffs+=$(jq -r '.patch' <<< "$file")
         diffs+=$'\n\n'
       fi
@@ -33,18 +33,6 @@ github::get_commit_diff() {
 
     echo "$diffs"
   fi
-}
-
-github::should_ignore_file() {
-  local -r filename="$1"
-  local -r files_to_ignore="$2"
-
-  for pattern in $files_to_ignore; do
-    # shellcheck disable=SC2053
-    [[ "$filename" == $pattern ]] && return 0
-  done
-
-  return 1
 }
 
 github::comment() {

--- a/src/gitlab.sh
+++ b/src/gitlab.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+GITLAB_API_HEADER="Content-Type: application/json"
+
+gitlab::api_request() {
+  local -r method="$1"
+  local -r api_url="$2"
+  local -r data="${3:-}"
+
+  local response
+  if [[ -n "$data" ]]; then
+    response=$(curl -sSL -w $'\n%{http_code}' \
+      -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+      -H "$GITLAB_API_HEADER" \
+      -X "$method" \
+      -d "$data" \
+      "$api_url")
+  else
+    response=$(curl -sSL -w $'\n%{http_code}' \
+      -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+      -H "$GITLAB_API_HEADER" \
+      -X "$method" \
+      "$api_url")
+  fi
+
+  local http_code body
+  http_code="${response##*$'\n'}"
+  body="${response%$'\n'*}"
+
+  if [[ ! "$http_code" =~ ^2 ]]; then
+    local error
+    error=$(jq -r '.message // .error // .' <<< "$body" 2>/dev/null || printf "%s" "$body")
+    utils::log_error "API request to GitLab failed with status $http_code: $error"
+  fi
+
+  printf "%s\n" "$body"
+}
+
+gitlab::get_merge_request_diff() {
+  local -r files_to_ignore="${1:-}"
+  local diffs=""
+  local page=1
+
+  while true; do
+    local page_body
+    page_body=$(gitlab::api_request \
+      "GET" \
+      "$CI_API_V4_URL/projects/$CI_PROJECT_ID/merge_requests/$CI_MERGE_REQUEST_IID/diffs?per_page=100&page=$page")
+
+    local page_length
+    page_length=$(jq 'length' <<< "$page_body")
+    [[ "$page_length" -eq 0 ]] && break
+
+    while IFS= read -r file; do
+      local filename deleted diff
+      filename=$(jq -r '.new_path' <<< "$file")
+      deleted=$(jq -r '.deleted_file // false' <<< "$file")
+      diff=$(jq -r '.diff // empty' <<< "$file")
+
+      [[ "$deleted" == "true" || -z "$diff" ]] && continue
+
+      if ! utils::should_ignore_file "$filename" "$files_to_ignore"; then
+        diffs+="$diff"
+        diffs+=$'\n\n'
+      fi
+    done < <(jq -c '.[]' <<< "$page_body")
+
+    page=$((page + 1))
+  done
+
+  printf "%s" "$diffs"
+}
+
+gitlab::comment() {
+  local -r comment="$1"
+  local -r api_url="$CI_API_V4_URL/projects/$CI_PROJECT_ID/merge_requests/$CI_MERGE_REQUEST_IID/notes"
+
+  gitlab::api_request \
+    "POST" \
+    "$api_url" \
+    "$(jq -n --arg comment "$comment" '{body: $comment}')"
+}

--- a/src/main.sh
+++ b/src/main.sh
@@ -7,17 +7,34 @@ export TOP_PID=$$
 
 source "$HOME_DIR/src/utils.sh"
 source "$HOME_DIR/src/github.sh"
+source "$HOME_DIR/src/gitlab.sh"
 source "$HOME_DIR/src/ai.sh"
 
 ##? Auto-reviews a Pull Request
 ##?
 ##? Usage:
-##?   main.sh --github_token=<token> --ai_provider=<provider> --ai_api_key=<key> --ai_model=<model> --github_api_url=<url> --files_to_ignore=<files> --open_ai_api_key=<token> --gpt_model_name=<name>
+##?   main.sh [--git_provider=<provider>] [--git_token=<token>] [--github_token=<token>] [--ai_provider=<provider>] [--ai_api_key=<key>] [--ai_model=<model>] [--github_api_url=<url>] [--files_to_ignore=<files>] [--open_ai_api_key=<token>] [--gpt_model_name=<name>]
 main() {
-  local github_token ai_provider ai_api_key ai_model github_api_url files_to_ignore
+  local git_provider git_token github_token ai_provider ai_api_key ai_model github_api_url files_to_ignore
   local open_ai_api_key gpt_model_name  # Legacy parameters
 
   eval "$(docpars -h "$(grep "^##?" "${BASH_SOURCE[0]}" | cut -c 5-)" : "$@")"
+
+  if [[ -z "${git_provider:-}" ]]; then
+    git_provider="github"
+  fi
+
+  if [[ -n "${github_token:-}" && -z "${git_token:-}" ]]; then
+    git_token="$github_token"
+  fi
+
+  if [[ -z "${github_api_url:-}" ]]; then
+    github_api_url="https://api.github.com"
+  fi
+
+  if [[ -z "${files_to_ignore:-}" ]]; then
+    files_to_ignore=""
+  fi
 
   # Handle backward compatibility - use legacy params if new ones aren't provided
   if [[ -n "${open_ai_api_key:-}" && -z "${ai_api_key:-}" ]]; then
@@ -50,17 +67,30 @@ main() {
     esac
   fi
 
-  utils::verify_required_env_vars
+  utils::verify_required_env_vars "git_provider" "git_token" "ai_api_key"
 
-  export GITHUB_TOKEN="$github_token"
-  export GITHUB_API_URL="$github_api_url"
   export AI_PROVIDER="$ai_provider"
   export AI_API_KEY="$ai_api_key"
   export AI_MODEL="$ai_model"
 
-  local pr_number commit_diff ai_response
-  pr_number=$(github::get_pr_number)
-  commit_diff=$(github::get_commit_diff "$pr_number" "${files_to_ignore[*]}")
+  local review_number commit_diff ai_response
+  case "$git_provider" in
+    "github")
+      utils::verify_required_env_vars "GITHUB_REPOSITORY" "GITHUB_EVENT_PATH" "github_api_url"
+      export GITHUB_TOKEN="$git_token"
+      export GITHUB_API_URL="$github_api_url"
+      review_number=$(github::get_pr_number)
+      commit_diff=$(github::get_commit_diff "$review_number" "$files_to_ignore")
+      ;;
+    "gitlab")
+      utils::verify_required_env_vars "CI_API_V4_URL" "CI_PROJECT_ID" "CI_MERGE_REQUEST_IID"
+      export GITLAB_TOKEN="$git_token"
+      commit_diff=$(gitlab::get_merge_request_diff "$files_to_ignore")
+      ;;
+    *)
+      utils::log_error "Unsupported git provider: $git_provider. Supported providers: github, gitlab"
+      ;;
+  esac
 
   if [[ -z "$commit_diff" ]]; then
     utils::log_info "Nothing in the commit diff."
@@ -71,8 +101,14 @@ main() {
 
   if [[ -z "$ai_response" ]]; then
     utils::log_error "AI response was empty. Double check your API key and billing details."
-    exit 1
   fi
 
-  github::comment "$ai_response" "$pr_number"
+  case "$git_provider" in
+    "github")
+      github::comment "$ai_response" "$review_number"
+      ;;
+    "gitlab")
+      gitlab::comment "$ai_response"
+      ;;
+  esac
 }

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -15,21 +15,30 @@ utils::log_error() {
 }
 
 utils::verify_required_env_vars() {
-  local required_vars=(
-    "GITHUB_REPOSITORY"
-    "GITHUB_EVENT_PATH"
-    "github_token"
-    "github_api_url"
-  )
-
-  for var in "${required_vars[@]}"; do
+  for var in "$@"; do
     utils::env_variable_exist "$var"
   done
 }
 
 utils::env_variable_exist() {
   local var_name="$1"
-  if [[ -z "${!var_name}" ]]; then
+  if [[ -z "${!var_name:-}" ]]; then
     utils::log_error "The env variable '$var_name' is required."
   fi
+}
+
+utils::should_ignore_file() {
+  local filename="$1"
+  local files_to_ignore="$2"
+
+  local pattern
+  for pattern in $files_to_ignore; do
+    pattern="${pattern%\"}"
+    pattern="${pattern#\"}"
+
+    # shellcheck disable=SC2053
+    [[ "$filename" == $pattern ]] && return 0
+  done
+
+  return 1
 }


### PR DESCRIPTION
## Summary
- add a git provider switch that keeps GitHub as the default while enabling GitLab merge request reviews
- add GitLab helpers for MR diffs, note comments, pagination, deleted-file skipping, and shared ignore-pattern handling
- publish a GHCR Docker image on releases so GitLab CI can run Robin AI directly
- document GitLab CI usage and token/API-key requirements
- update the self-review workflow and Claude docs example to the current Claude default model

## Supersedes
- Rebuilds the still-relevant GitLab support from #35 on top of current main.
- Leaves the old quality-of-life pieces alone since they were already split out and merged in #36.

## Validation
- shellcheck -x src/*.sh entrypoint.sh
- git diff --check
- mocked bash assertion for quoted files_to_ignore and GitLab diff filtering
- SKIP=shellcheck pre-commit run --all-files

Note: full pre-commit and the normal commit hook could not complete because the configured ShellCheck hook invokes Docker, and Docker Desktop is not running locally. The equivalent local ShellCheck command passes.