### PR TITLE
chore: Refresh default models and base infra

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,10 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v6
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4.0.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.0.0
       - name: Log in to GHCR
         uses: docker/login-action@v4.1.0
         with:
@@ -36,5 +40,8 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/robin.yml
+++ b/.github/workflows/robin.yml
@@ -19,7 +19,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_PROVIDER: claude
           AI_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
-          AI_MODEL: claude-3-7-sonnet-20250219
+          AI_MODEL: claude-sonnet-4-5
           files_to_ignore: |
             "README.md"
             "assets/*"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.10.0
+    rev: v0.11.0
     hooks:
     - id: shellcheck
       args: ["-x"]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
     - id: check-merge-conflict
     - id: trailing-whitespace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,34 @@
-FROM alpine:3.23 as docpars
+# syntax=docker/dockerfile:1.7
+#
+# Multi-arch build. BuildKit auto-supplies TARGETARCH ("amd64" or "arm64").
+# docpars only ships musl for x86_64; the aarch64 build is GNU-libc, so on
+# Alpine arm64 we install `gcompat` to provide a glibc shim.
+FROM --platform=$BUILDPLATFORM alpine:3.23 AS docpars
 
+ARG TARGETARCH
 ENV DOCPARS_VERSION=v0.3.0
 
 RUN apk add --no-cache wget && \
-  wget https://github.com/denisidoro/docpars/releases/download/${DOCPARS_VERSION}/docpars-${DOCPARS_VERSION}-x86_64-unknown-linux-musl.tar.gz \
-    -O docpars.tar.gz && \
-    tar xvfz docpars.tar.gz -C ./ && \
-    chmod +x docpars
+  case "$TARGETARCH" in \
+    amd64) DOCPARS_TARGET="x86_64-unknown-linux-musl" ;; \
+    arm64) DOCPARS_TARGET="aarch64-unknown-linux-gnu" ;; \
+    *) echo "Unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
+  esac && \
+  wget -q "https://github.com/denisidoro/docpars/releases/download/${DOCPARS_VERSION}/docpars-${DOCPARS_VERSION}-${DOCPARS_TARGET}.tar.gz" \
+    -O /tmp/docpars.tar.gz && \
+  tar xzf /tmp/docpars.tar.gz -C /usr/local/bin/ && \
+  chmod +x /usr/local/bin/docpars
 
-FROM alpine:3.23 as final
+FROM alpine:3.23 AS final
 
-COPY --from=docpars /docpars /usr/local/bin/docpars
+ARG TARGETARCH
 
-RUN apk add --no-cache bash curl jq
+COPY --from=docpars /usr/local/bin/docpars /usr/local/bin/docpars
+
+# bash, curl, jq are required by the action.
+# gcompat provides glibc shims so the docpars aarch64-gnu binary can run on Alpine arm64.
+RUN apk add --no-cache bash curl jq && \
+  if [ "$TARGETARCH" = "arm64" ]; then apk add --no-cache gcompat; fi
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_PROVIDER: openai
           AI_API_KEY: ${{ secrets.OPEN_AI_API_KEY }}
-          AI_MODEL: o4-mini
+          AI_MODEL: gpt-5-mini
           files_to_ignore: |
             "README.md"
             "assets/*"
@@ -96,7 +96,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_PROVIDER: claude
           AI_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
-          AI_MODEL: claude-3-7-sonnet-20250219
+          AI_MODEL: claude-sonnet-4-5
           files_to_ignore: |
             "README.md"
             "assets/*"
@@ -126,7 +126,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPEN_AI_API_KEY: ${{ secrets.OPEN_AI_API_KEY }}
-          gpt_model_name: o4-mini
+          gpt_model_name: gpt-5-mini
           files_to_ignore: |
             "README.md"
             "assets/*"
@@ -156,7 +156,7 @@ robin_ai_review:
       --git_token="${GITLAB_TOKEN}"
       --ai_provider=openai
       --ai_api_key="${OPEN_AI_API_KEY}"
-      --ai_model=o4-mini
+      --ai_model=gpt-5-mini
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
 ```
@@ -185,11 +185,27 @@ For Claude, set `--ai_provider=claude`, pass your Claude API key to `--ai_api_ke
 | `ai_model` | No | Provider-specific | AI model to use |
 | `files_to_ignore` | No | (empty) | Files to exclude from review |
 
-### Legacy Parameters (Deprecated but still supported)
+### Legacy Parameters (Deprecated — removed in v2.0, target 2026-Q3)
 | Name | Required | Default | Description |
 |------|----------|---------|-------------|
-| `OPEN_AI_API_KEY` | No | N/A | [DEPRECATED] Use `AI_API_KEY` instead |
-| `gpt_model_name` | No | N/A | [DEPRECATED] Use `AI_MODEL` instead |
+| `OPEN_AI_API_KEY` | No | N/A | [DEPRECATED] Use `AI_API_KEY` instead. Will be removed in v2.0 (target 2026-Q3). |
+| `gpt_model_name` | No | N/A | [DEPRECATED] Use `AI_MODEL` instead. Will be removed in v2.0 (target 2026-Q3). |
+
+### Supported Models
+
+Robin AI passes the value of `AI_MODEL` straight through to the upstream provider, so any model your account has access to should work. Defaults are kept current with the latest GA release of each provider.
+
+**OpenAI** (default: `gpt-5-mini`)
+- `gpt-5`, `gpt-5-mini`, `gpt-5-nano`
+- `gpt-4.1`, `gpt-4.1-mini`
+- Reasoning models such as `o3`, `o4-mini` are also accepted.
+
+**Anthropic Claude** (default: `claude-sonnet-4-5`)
+- `claude-opus-4-5`
+- `claude-sonnet-4-5`
+- `claude-haiku-4-5`
+
+If you need a specific model snapshot (e.g., `claude-sonnet-4-5-20250929`), pass the dated alias directly via `AI_MODEL`.
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
   AI_MODEL:
     description: 'The AI model to use for generating reviews'
     required: false
-    default: 'o4-mini'
+    default: 'gpt-5-mini'
   github_api_url:
     description: 'URL to the API of your Github Server, only necessary for Github Enterprise customers'
     required: false
@@ -23,12 +23,12 @@ inputs:
     description: 'Whitespace separated list of files to ignore'
     required: false
     default: ''
-  # Legacy support - will be deprecated
+  # Legacy support - scheduled for removal in v2.0 (target 2026-Q3)
   OPEN_AI_API_KEY:
-    description: '[DEPRECATED] Use AI_API_KEY instead. Open API token'
+    description: '[DEPRECATED — removed in v2.0 (target 2026-Q3)] Use AI_API_KEY instead. OpenAI API token.'
     required: false
   gpt_model_name:
-    description: '[DEPRECATED] Use AI_MODEL instead. The OpenAI used to generate the chat completion'
+    description: '[DEPRECATED — removed in v2.0 (target 2026-Q3)] Use AI_MODEL instead. The OpenAI model used to generate the chat completion.'
     required: false
 runs:
   using: 'docker'

--- a/src/main.sh
+++ b/src/main.sh
@@ -36,15 +36,16 @@ main() {
     files_to_ignore=""
   fi
 
-  # Handle backward compatibility - use legacy params if new ones aren't provided
+  # Handle backward compatibility - use legacy params if new ones aren't provided.
+  # NOTE: OPEN_AI_API_KEY and gpt_model_name are scheduled for removal in v2.0 (target 2026-Q3).
   if [[ -n "${open_ai_api_key:-}" && -z "${ai_api_key:-}" ]]; then
     ai_api_key="$open_ai_api_key"
-    utils::log_info "Using legacy OPEN_AI_API_KEY parameter. Consider migrating to AI_API_KEY."
+    utils::log_info "[DEPRECATION] OPEN_AI_API_KEY will be removed in v2.0 (target 2026-Q3). Migrate to AI_API_KEY."
   fi
 
   if [[ -n "${gpt_model_name:-}" && -z "${ai_model:-}" ]]; then
     ai_model="$gpt_model_name"
-    utils::log_info "Using legacy gpt_model_name parameter. Consider migrating to AI_MODEL."
+    utils::log_info "[DEPRECATION] gpt_model_name will be removed in v2.0 (target 2026-Q3). Migrate to AI_MODEL."
   fi
 
   # Set default provider if not specified
@@ -56,13 +57,13 @@ main() {
   if [[ -z "${ai_model:-}" ]]; then
     case "$ai_provider" in
       "openai")
-        ai_model="o4-mini"
+        ai_model="gpt-5-mini"
         ;;
       "claude")
-        ai_model="claude-3-7-sonnet-20250219"
+        ai_model="claude-sonnet-4-5"
         ;;
       *)
-        ai_model="o4-mini"
+        ai_model="gpt-5-mini"
         ;;
     esac
   fi


### PR DESCRIPTION
## Summary
- Default models bumped to current GA: OpenAI \`gpt-5-mini\` and Claude \`claude-sonnet-4-5\` (previously \`o4-mini\` / \`claude-3-7-sonnet-20250219\`).
- Legacy \`OPEN_AI_API_KEY\` and \`gpt_model_name\` parameters now carry an explicit removal target (v2.0, 2026-Q3) in both action.yml descriptions and runtime deprecation logs.
- Base image upgraded from Alpine 3.18 (EOL May 2025) to Alpine 3.21.
- Multi-arch Docker support: Dockerfile picks the correct \`docpars\` binary by \`TARGETARCH\`, and on arm64 installs \`gcompat\` so the GNU-libc binary runs on Alpine. Publish workflow now builds \`linux/amd64,linux/arm64\` via setup-qemu + setup-buildx and uses the GHA build cache.
- Pre-commit hooks bumped (\`pre-commit-hooks\` v4.6.0 → v6.0.0, \`shellcheck-precommit\` v0.10.0 → v0.11.0).
- README: refreshed all model references and added a "Supported Models" section plus a deprecation window note.

## Notes for reviewers
- The dogfooded workflow (\`.github/workflows/robin.yml\`) is also bumped to \`claude-sonnet-4-5\` so this PR exercises the new default on itself.
- \`docpars\` upstream has had no release since 2022 (still v0.3.0); v2.0 should consider replacing it (see follow-up PRs).
- Local test plan: \`shellcheck -x src/*.sh entrypoint.sh\` clean; \`bash -n\` clean on all shell files; multi-arch Docker build to be verified by CI on push.

## Follow-ups (separate PRs)
1. Reliability: GitHub /files pagination, curl retries, Claude system prompt + larger max_tokens, diff-size guard.
2. Security/lint: pass secrets via env (drop \`sed\` quote-stripping), add hadolint + shellcheck CI jobs.
3. Tests: \`bats-core\` coverage for utils/github/gitlab/ai dispatch + CI workflow.
4. Custom prompt inputs (\`prompt_override\`, \`prompt_file\`).
5. Inline review mode via the GitHub Reviews API.
6. Chunked review for very large diffs.