### PR TITLE
chore: Pass secrets via env, drop fragile arg sanitization, lint hardening

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,13 +3,24 @@ name: Lint
 on: [pull_request]
 
 jobs:
-  lint:
+  shellcheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@2.0.0
         with:
-          severity: error
-          scandir: './src'
+          severity: warning
+          scandir: '.'
+
+  hadolint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run Hadolint
+        uses: hadolint/hadolint-action@v3.3.0
+        with:
+          dockerfile: Dockerfile
+          failure-threshold: warning

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ FROM --platform=$BUILDPLATFORM alpine:3.23 AS docpars
 ARG TARGETARCH
 ENV DOCPARS_VERSION=v0.3.0
 
+# hadolint ignore=DL3018
 RUN apk add --no-cache wget && \
   case "$TARGETARCH" in \
     amd64) DOCPARS_TARGET="x86_64-unknown-linux-musl" ;; \
@@ -27,6 +28,7 @@ COPY --from=docpars /usr/local/bin/docpars /usr/local/bin/docpars
 
 # bash, curl, jq are required by the action.
 # gcompat provides glibc shims so the docpars aarch64-gnu binary can run on Alpine arm64.
+# hadolint ignore=DL3018
 RUN apk add --no-cache bash curl jq && \
   if [ "$TARGETARCH" = "arm64" ]; then apk add --no-cache gcompat; fi
 

--- a/README.md
+++ b/README.md
@@ -149,13 +149,15 @@ robin_ai_review:
     name: ghcr.io/integral-healthcare/robin-ai-reviewer:latest
     entrypoint: [""]
   stage: test
+  variables:
+    # Pass secrets via env so they don't show up in argv / `ps` / job logs.
+    AI_API_KEY_INPUT: $OPEN_AI_API_KEY
   script:
     - >
       /entrypoint.sh
       --git_provider=gitlab
       --git_token="${GITLAB_TOKEN}"
       --ai_provider=openai
-      --ai_api_key="${OPEN_AI_API_KEY}"
       --ai_model=gpt-5-mini
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'

--- a/action.yml
+++ b/action.yml
@@ -41,16 +41,20 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  # Secrets are passed via env so they don't appear in `ps` listings or in
+  # the workflow log when the entrypoint echoes its arguments. Non-secret
+  # configuration is still passed via args.
+  env:
+    GITHUB_TOKEN_INPUT: ${{ inputs.GITHUB_TOKEN }}
+    AI_API_KEY_INPUT: ${{ inputs.AI_API_KEY }}
+    OPEN_AI_API_KEY_INPUT: ${{ inputs.OPEN_AI_API_KEY }}
   args:
-    - --github_token=${{ inputs.GITHUB_TOKEN }}
     - --ai_provider=${{ inputs.AI_PROVIDER }}
-    - --ai_api_key=${{ inputs.AI_API_KEY }}
     - --ai_model=${{ inputs.AI_MODEL }}
     - --ai_max_tokens=${{ inputs.ai_max_tokens }}
     - --max_diff_bytes=${{ inputs.max_diff_bytes }}
     - --github_api_url=${{ inputs.github_api_url }}
     - --files_to_ignore=${{ inputs.files_to_ignore }}
-    - --open_ai_api_key=${{ inputs.OPEN_AI_API_KEY }}
     - --gpt_model_name=${{ inputs.gpt_model_name }}
 branding:
   icon: 'tag'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,11 +11,6 @@ export HOME_DIR
 
 source "$HOME_DIR/src/main.sh"
 
-for a in "${@}"; do
-  arg=$(echo "$a" | tr '\n' ' ' | xargs echo | sed "s/'//g"| sed "s/’//g")
-  sanitizedArgs+=("$arg")
-done
-
-main "${sanitizedArgs[@]}"
+main "$@"
 
 exit $?

--- a/src/main.sh
+++ b/src/main.sh
@@ -20,6 +20,20 @@ main() {
 
   eval "$(docpars -h "$(grep "^##?" "${BASH_SOURCE[0]}" | cut -c 5-)" : "$@")"
 
+  # Prefer secrets passed via env (so they don't show up in `ps` or be
+  # echoed back into workflow logs). Fall back to CLI flags so the
+  # docker / GitLab CI usage still works for users invoking the entrypoint
+  # directly.
+  if [[ -n "${GITHUB_TOKEN_INPUT:-}" && -z "${github_token:-}" ]]; then
+    github_token="$GITHUB_TOKEN_INPUT"
+  fi
+  if [[ -n "${AI_API_KEY_INPUT:-}" && -z "${ai_api_key:-}" ]]; then
+    ai_api_key="$AI_API_KEY_INPUT"
+  fi
+  if [[ -n "${OPEN_AI_API_KEY_INPUT:-}" && -z "${open_ai_api_key:-}" ]]; then
+    open_ai_api_key="$OPEN_AI_API_KEY_INPUT"
+  fi
+
   if [[ -z "${git_provider:-}" ]]; then
     git_provider="github"
   fi


### PR DESCRIPTION
> Stacked on top of #64 (which is stacked on #63). Review the parents first.

## Summary
- Move \`GITHUB_TOKEN\`, \`AI_API_KEY\`, and \`OPEN_AI_API_KEY\` out of the docker \`args:\` interpolation into the action's \`env:\` block (as \`*_INPUT\` vars). They no longer appear in \`ps\` listings or in workflow logs that echo argv. \`src/main.sh\` reads the env vars and falls back to the CLI flags so the GitLab CI / direct-entrypoint usage keeps working.
- Delete the \`sed\`-based quote-stripping in \`entrypoint.sh\`. It was a brittle band-aid against shell injection that also corrupted any legitimate \`'\` or smart-quote characters in \`files_to_ignore\`.
- \`lint.yml\`: shellcheck now scans the repo (\`scandir: '.'\`) so \`entrypoint.sh\` is covered, threshold raised to \`warning\`, action pinned to \`ludeeus/action-shellcheck@2.0.0\`. Added a hadolint job pinned to \`v3.3.0\` with the same threshold.
- Suppress the two \`DL3018\` (pin apk versions) findings inline; pinning would block Alpine security updates.

## Test plan
- \`shellcheck -x src/*.sh entrypoint.sh\` clean.
- \`hadolint Dockerfile\` clean (after suppressions).
- Smoke-test verifies env-fallback path populates \`github_token\` / \`ai_api_key\` when CLI flags are absent.

## Backward compatibility
- The GitHub Action surface is unchanged — users still set inputs via the workflow's \`with:\` block.
- The \`/entrypoint.sh --git_token=… --ai_api_key=…\` invocation continues to work.
- Recommend (but don't require) GitLab users move secrets to \`variables:\` (\`AI_API_KEY_INPUT\`); the README sample is updated.

## Follow-ups (separate PRs)
4. Tests via \`bats-core\` + custom prompt inputs.
5. Inline review mode (Reviews API).
6. Chunked review for very large diffs.