### PR TITLE
feat: Add review_mode for line-anchored inline review comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ For Claude, set `--ai_provider=claude`, pass your Claude API key to `--ai_api_ke
 | `max_diff_bytes` | No | `200000` | Soft cap on diff size in bytes; larger diffs are truncated before being sent to the model |
 | `prompt_override` | No | (empty) | Inline replacement for the system prompt. Takes precedence over `prompt_file`. |
 | `prompt_file` | No | (empty) | Path to a file in the workspace containing the system prompt to use instead of the bundled default. |
+| `review_mode` | No | `comment` | `comment` for one summary PR comment; `review` for inline line-anchored comments via the GitHub Reviews API. |
 | `github_api_url` | No | `https://api.github.com` | GitHub API URL (for enterprise) |
 | `files_to_ignore` | No | (empty) | Files to exclude from review |
 
@@ -216,6 +217,19 @@ Robin AI passes the value of `AI_MODEL` straight through to the upstream provide
 - `claude-haiku-4-5`
 
 If you need a specific model snapshot (e.g., `claude-sonnet-4-5-20250929`), pass the dated alias directly via `AI_MODEL`.
+
+### Inline review mode
+
+Set `review_mode: review` to have Robin post line-anchored comments via the GitHub Reviews API instead of one summary PR comment. In this mode the prompt asks the model for structured JSON, the response is validated against the diff, and any hallucinated line references are dropped before the review is posted. If the model returns invalid JSON, Robin falls back to the standard summary comment.
+
+```yml
+- uses: Integral-Healthcare/robin-ai-reviewer@v[INSERT_LATEST_RELEASE]
+  with:
+    AI_API_KEY: ${{ secrets.OPEN_AI_API_KEY }}
+    review_mode: review
+```
+
+Inline review currently requires GitHub. On GitLab the value is silently downgraded to `comment`.
 
 ### Custom prompts
 

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: 'Path (inside the workspace) to a file containing the system prompt to use instead of the bundled default.'
     required: false
     default: ''
+  review_mode:
+    description: 'Output format: "comment" (default; single PR comment) or "review" (inline line-anchored comments via the GitHub Reviews API).'
+    required: false
+    default: 'comment'
   github_api_url:
     description: 'URL to the API of your Github Server, only necessary for Github Enterprise customers'
     required: false
@@ -63,6 +67,7 @@ runs:
     - --max_diff_bytes=${{ inputs.max_diff_bytes }}
     - --prompt_override=${{ inputs.prompt_override }}
     - --prompt_file=${{ inputs.prompt_file }}
+    - --review_mode=${{ inputs.review_mode }}
     - --github_api_url=${{ inputs.github_api_url }}
     - --files_to_ignore=${{ inputs.files_to_ignore }}
     - --gpt_model_name=${{ inputs.gpt_model_name }}

--- a/src/main.sh
+++ b/src/main.sh
@@ -9,13 +9,14 @@ source "$HOME_DIR/src/utils.sh"
 source "$HOME_DIR/src/github.sh"
 source "$HOME_DIR/src/gitlab.sh"
 source "$HOME_DIR/src/ai.sh"
+source "$HOME_DIR/src/review.sh"
 
 ##? Auto-reviews a Pull Request
 ##?
 ##? Usage:
-##?   main.sh [--git_provider=<provider>] [--git_token=<token>] [--github_token=<token>] [--ai_provider=<provider>] [--ai_api_key=<key>] [--ai_model=<model>] [--ai_max_tokens=<n>] [--max_diff_bytes=<n>] [--prompt_override=<text>] [--prompt_file=<path>] [--github_api_url=<url>] [--files_to_ignore=<files>] [--open_ai_api_key=<token>] [--gpt_model_name=<name>]
+##?   main.sh [--git_provider=<provider>] [--git_token=<token>] [--github_token=<token>] [--ai_provider=<provider>] [--ai_api_key=<key>] [--ai_model=<model>] [--ai_max_tokens=<n>] [--max_diff_bytes=<n>] [--prompt_override=<text>] [--prompt_file=<path>] [--review_mode=<mode>] [--github_api_url=<url>] [--files_to_ignore=<files>] [--open_ai_api_key=<token>] [--gpt_model_name=<name>]
 main() {
-  local git_provider git_token github_token ai_provider ai_api_key ai_model ai_max_tokens max_diff_bytes prompt_override prompt_file github_api_url files_to_ignore
+  local git_provider git_token github_token ai_provider ai_api_key ai_model ai_max_tokens max_diff_bytes prompt_override prompt_file review_mode github_api_url files_to_ignore
   local open_ai_api_key gpt_model_name  # Legacy parameters
 
   eval "$(docpars -h "$(grep "^##?" "${BASH_SOURCE[0]}" | cut -c 5-)" : "$@")"
@@ -97,6 +98,23 @@ main() {
     export AI_PROMPT_FILE="$prompt_file"
   fi
 
+  # Review mode: "comment" (default; one issue comment) or "review" (inline
+  # review via the GitHub Reviews API). Inline mode is currently GitHub-only.
+  if [[ -z "${review_mode:-}" ]]; then
+    review_mode="comment"
+  fi
+  if [[ "$review_mode" == "review" && "$git_provider" != "github" ]]; then
+    utils::log_info "review_mode=review only supported on GitHub; falling back to comment."
+    review_mode="comment"
+  fi
+  if [[ "$review_mode" == "review" ]]; then
+    # Override the prompt so the model emits structured JSON. User-supplied
+    # overrides still win — they may have their own JSON schema.
+    if [[ -z "${AI_PROMPT_OVERRIDE:-}" && -z "${AI_PROMPT_FILE:-}" ]]; then
+      export AI_PROMPT_OVERRIDE="$INLINE_REVIEW_PROMPT"
+    fi
+  fi
+
   # Soft cap on the diff size we send to the model. Anything larger gets
   # truncated so a giant PR doesn't blow the context window or rack up
   # surprise spend. Defaults to 200000 bytes (~50k tokens).
@@ -142,7 +160,11 @@ main() {
 
   case "$git_provider" in
     "github")
-      github::comment "$ai_response" "$review_number"
+      if [[ "$review_mode" == "review" ]]; then
+        review::create "$ai_response" "$review_number" "$commit_diff"
+      else
+        github::comment "$ai_response" "$review_number"
+      fi
       ;;
     "gitlab")
       gitlab::comment "$ai_response"

--- a/src/review.sh
+++ b/src/review.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+# Helpers for "review" mode: instead of a single PR comment, the AI is asked
+# to return structured JSON which we then turn into line-anchored review
+# comments via the GitHub Reviews API.
+
+# shellcheck disable=SC2034  # consumed by main.sh
+INLINE_REVIEW_PROMPT=$(cat <<'EOF'
+You are a Pull Request Code Reviewer. Review the unified diff below and
+respond with a single JSON object — and nothing else — that conforms to:
+
+{
+  "summary": "Short overall summary of the change set (max 1 paragraph).",
+  "score": 0-100,
+  "comments": [
+    {
+      "path": "path/to/file.py",
+      "line": <integer line number from the new (right) side of the diff>,
+      "body": "Specific, actionable feedback for that line."
+    }
+  ]
+}
+
+Rules:
+- Only return inline comments for lines that appear as additions (lines
+  prefixed with `+`) in the diff. Do not comment on context or removed lines.
+- `line` must be the absolute line number in the new file as shown by the
+  hunk header (e.g., `@@ -12,3 +20,5 @@` means the new side starts at 20).
+- If everything looks good, return an empty `comments` array and put your
+  positive remarks in `summary`.
+- Do not wrap the JSON in code fences or prose. The response MUST be parseable
+  by `jq`.
+EOF
+)
+
+# review::diff_added_lines reads a unified diff on stdin and prints
+# `<path>\t<new_line_number>` for every line in the new file that actually
+# exists in the diff (added or unchanged-context). Used to validate AI
+# suggestions before sending them to GitHub.
+review::diff_added_lines() {
+  awk '
+    /^diff --git a\// {
+      # New file boundary; reset state.
+      path = ""
+      next
+    }
+    /^\+\+\+ b\// {
+      path = substr($0, 7)
+      next
+    }
+    /^@@ / {
+      # @@ -old,oldlen +new,newlen @@
+      match($0, /\+[0-9]+/)
+      new_line = substr($0, RSTART + 1, RLENGTH - 1) + 0
+      next
+    }
+    path == "" || new_line == 0 { next }
+    /^\+/ && !/^\+\+\+/ {
+      print path "\t" new_line
+      new_line++
+      next
+    }
+    /^-/ && !/^---/ {
+      next
+    }
+    /^ / || /^$/ {
+      new_line++
+      next
+    }
+  '
+}
+
+# review::filter_comments keeps only comments whose (path, line) pairs
+# correspond to an added line in the diff. Reads:
+#   - stdin:        unified diff
+#   - $1:           comments JSON array
+# Prints the filtered array to stdout.
+review::filter_comments() {
+  local -r comments_json="$1"
+  local valid_pairs
+  valid_pairs="$(review::diff_added_lines)"
+
+  if [[ -z "$valid_pairs" ]]; then
+    echo "[]"
+    return 0
+  fi
+
+  jq --arg pairs "$valid_pairs" '
+    ($pairs | split("\n") | map(select(length > 0))) as $valid
+    | map(select(((.path // "") + "\t" + ((.line // 0) | tostring)) as $key
+                 | $valid | index($key)))
+  ' <<< "$comments_json"
+}
+
+# review::create posts a GitHub PR review with inline comments. Falls back
+# to a plain issue comment if the AI response isn't valid JSON.
+#
+# Args:
+#   $1 raw AI response (expected to be JSON)
+#   $2 PR number
+#   $3 unified diff (used to validate inline comment positions)
+review::create() {
+  local -r ai_response="$1"
+  local -r pr_number="$2"
+  local -r diff="$3"
+
+  local stripped
+  stripped="$(printf '%s' "$ai_response" | sed -e 's/^```json//' -e 's/^```//' -e 's/```$//')"
+
+  if ! jq -e '.' >/dev/null 2>&1 <<< "$stripped"; then
+    utils::log_info "Inline-review JSON parse failed; falling back to a plain comment."
+    github::comment "$ai_response" "$pr_number"
+    return
+  fi
+
+  local summary score comments
+  summary="$(jq -r '.summary // ""' <<< "$stripped")"
+  score="$(jq -r '.score // empty' <<< "$stripped")"
+  comments="$(jq -c '.comments // []' <<< "$stripped")"
+
+  comments="$(printf '%s' "$diff" | review::filter_comments "$comments")"
+
+  local body="$summary"
+  if [[ -n "$score" ]]; then
+    body="**Score: $score/100**"$'\n\n'"$summary"
+  fi
+
+  local payload
+  payload="$(jq -n \
+    --arg body "$body" \
+    --argjson comments "$comments" \
+    '{
+      event: "COMMENT",
+      body: $body,
+      comments: ($comments | map({path, line, body, side: "RIGHT"}))
+    }')"
+
+  local api_url="$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/pulls/$pr_number/reviews"
+  curl -sSL \
+    --retry 3 --retry-delay 2 --retry-connrefused --max-time 60 \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github.v3+json" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    "$api_url"
+}

--- a/tests/review.bats
+++ b/tests/review.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+
+setup() {
+  load test_helper
+  load_sources
+  # review.sh isn't auto-loaded by test_helper so far.
+  # shellcheck source=../src/review.sh
+  source "$HOME_DIR/src/review.sh"
+}
+
+# Sample diff used by several tests below.
+#
+# src/foo.py hunk starts at new-file line 10:
+#   line 10: ctx_a       (context)
+#   line 11: ctx_b       (context)
+#   line 12: added_12    (+ added)
+#   line 13: ctx_c       (context)
+#   line 14: added_14    (+ added)
+#
+# src/bar.py hunk starts at new-file line 20:
+#   line 20: ctx_x       (context)
+#   line 21: ctx_y       (context)
+#   line 22: added_22    (+ added)
+SAMPLE_DIFF='diff --git a/src/foo.py b/src/foo.py
+--- a/src/foo.py
++++ b/src/foo.py
+@@ -8,4 +10,5 @@ def existing():
+ ctx_a
+ ctx_b
++added_12
+ ctx_c
++added_14
+diff --git a/src/bar.py b/src/bar.py
+--- a/src/bar.py
++++ b/src/bar.py
+@@ -18,2 +20,3 @@
+ ctx_x
+ ctx_y
++added_22
+'
+
+@test "diff_added_lines: emits path/line for added lines on the new side" {
+  result="$(printf '%s' "$SAMPLE_DIFF" | review::diff_added_lines)"
+  [[ "$result" == *"src/foo.py"$'\t'"12"* ]]
+  [[ "$result" == *"src/foo.py"$'\t'"14"* ]]
+  [[ "$result" == *"src/bar.py"$'\t'"22"* ]]
+}
+
+@test "diff_added_lines: does not emit removed lines" {
+  diff='diff --git a/x.py b/x.py
+--- a/x.py
++++ b/x.py
+@@ -1,2 +1,1 @@
+-removed_old
+ kept
+'
+  result="$(printf '%s' "$diff" | review::diff_added_lines)"
+  [[ -z "$result" ]] || [[ "$result" != *"removed_old"* ]]
+}
+
+@test "filter_comments: keeps comments whose (path,line) match an added line" {
+  comments='[
+    {"path":"src/foo.py","line":12,"body":"good catch"},
+    {"path":"src/bar.py","line":22,"body":"nice"},
+    {"path":"src/foo.py","line":99,"body":"hallucinated"}
+  ]'
+  filtered="$(printf '%s' "$SAMPLE_DIFF" | review::filter_comments "$comments")"
+  count=$(jq 'length' <<< "$filtered")
+  [ "$count" -eq 2 ]
+  [[ "$filtered" == *'"line": 12'* ]]
+  [[ "$filtered" == *'"line": 22'* ]]
+  [[ "$filtered" != *'"line": 99'* ]]
+}
+
+@test "filter_comments: drops comments on lines not in the diff" {
+  comments='[{"path":"src/foo.py","line":1,"body":"out of range"}]'
+  filtered="$(printf '%s' "$SAMPLE_DIFF" | review::filter_comments "$comments")"
+  count=$(jq 'length' <<< "$filtered")
+  [ "$count" -eq 0 ]
+}
+
+@test "create: invalid JSON falls back to plain comment" {
+  export GITHUB_API_URL="https://api.github.example"
+  export GITHUB_REPOSITORY="acme/widget"
+  export GITHUB_TOKEN="t"
+
+  github::comment() {
+    echo "FALLBACK_COMMENT($1|$2)"
+  }
+  curl() {
+    echo "CURL_CALLED"
+  }
+
+  run review::create "this is not json" 42 "$SAMPLE_DIFF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"FALLBACK_COMMENT(this is not json|42)"* ]]
+  [[ "$output" != *"CURL_CALLED"* ]]
+}
+
+@test "create: valid JSON posts a review with filtered inline comments" {
+  export GITHUB_API_URL="https://api.github.example"
+  export GITHUB_REPOSITORY="acme/widget"
+  export GITHUB_TOKEN="t"
+
+  # Capture what curl is asked to send.
+  curl() {
+    # The payload is the value of the -d argument; print it back so the
+    # test can inspect it.
+    while [ $# -gt 0 ]; do
+      if [[ "$1" == "-d" ]]; then
+        printf 'PAYLOAD=%s\n' "$2"
+      fi
+      shift
+    done
+    echo '{"id":42,"state":"COMMENTED"}'
+  }
+
+  ai='{"summary":"LGTM overall","score":92,"comments":[
+    {"path":"src/foo.py","line":12,"body":"comment1"},
+    {"path":"src/foo.py","line":99,"body":"hallucinated"}
+  ]}'
+
+  run review::create "$ai" 42 "$SAMPLE_DIFF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"\"event\": \"COMMENT\""* ]]
+  [[ "$output" == *"comment1"* ]]
+  [[ "$output" != *"hallucinated"* ]]
+  [[ "$output" == *"Score: 92"* ]]
+}


### PR DESCRIPTION
> Stacked on top of #66 → #65 → #64 → #63. Review the parents first.

## Summary
- New \`review_mode\` input (\`comment\` default for backward compat, \`review\` for inline GitHub PR reviews).
- Adds \`src/review.sh\` with:
  - \`INLINE_REVIEW_PROMPT\` — used as the system prompt in review mode unless the user has supplied their own override.
  - \`review::diff_added_lines\` — awk-based parser that walks the unified diff and emits every \`(path, new-side line number)\` pair.
  - \`review::filter_comments\` — drops AI comments whose line references don't correspond to a real line in the diff. Cheap defense against model hallucination.
  - \`review::create\` — assembles and POSTs the Reviews API payload. Falls back to a plain issue comment if the AI response isn't valid JSON.
- \`main.sh\` dispatches to \`review::create\` on GitHub when \`review_mode=review\`. GitLab silently downgrades to comment.
- 6 new bats tests cover the diff parser, hallucination filtering, JSON-failure fallback, and the happy-path payload shape.

## Test plan
- All 35 bats tests pass locally (29 existing + 6 new).
- \`shellcheck -x src/*.sh entrypoint.sh\` clean.
- \`hadolint Dockerfile\` clean.

## Backward compatibility
- Default remains \`comment\`; existing users see no change.
- Custom \`prompt_override\` / \`prompt_file\` still win in review mode (so a user with their own JSON schema can keep using it).

## Follow-ups
6. Chunked review for very large diffs.