### PR TITLE
feat: Add per-file chunked review for large diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ For Claude, set `--ai_provider=claude`, pass your Claude API key to `--ai_api_ke
 | `AI_MODEL` | No | Provider-specific | AI model to use (see supported models below) |
 | `ai_max_tokens` | No | `8192` | Maximum tokens the model may generate in its review |
 | `max_diff_bytes` | No | `200000` | Soft cap on diff size in bytes; larger diffs are truncated before being sent to the model |
+| `chunk_threshold_bytes` | No | `100000` | When the diff exceeds this many bytes, split per-file and review each chunk individually. Set to `0` to disable. Ignored in `review_mode=review`. |
 | `prompt_override` | No | (empty) | Inline replacement for the system prompt. Takes precedence over `prompt_file`. |
 | `prompt_file` | No | (empty) | Path to a file in the workspace containing the system prompt to use instead of the bundled default. |
 | `review_mode` | No | `comment` | `comment` for one summary PR comment; `review` for inline line-anchored comments via the GitHub Reviews API. |
@@ -217,6 +218,12 @@ Robin AI passes the value of `AI_MODEL` straight through to the upstream provide
 - `claude-haiku-4-5`
 
 If you need a specific model snapshot (e.g., `claude-sonnet-4-5-20250929`), pass the dated alias directly via `AI_MODEL`.
+
+### Large pull requests
+
+By default, when the combined diff exceeds `chunk_threshold_bytes` (100KB), Robin splits the diff per file and reviews each file with its own AI call. The aggregated feedback is posted as a single comment with one section per file. This avoids the "diff truncated" path on big PRs and keeps reviews actionable on a per-file basis.
+
+Set `chunk_threshold_bytes: 0` to disable chunking entirely, or raise the threshold for models with larger context windows. Chunked review is currently bypassed when `review_mode: review` is set; that combination is a future enhancement.
 
 ### Inline review mode
 

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Soft cap on diff size in bytes before truncation (default: 200000)'
     required: false
     default: ''
+  chunk_threshold_bytes:
+    description: 'When the diff exceeds this many bytes, split per-file and review each chunk individually (default: 100000; 0 to disable). Ignored in review_mode=review.'
+    required: false
+    default: ''
   prompt_override:
     description: 'Inline replacement for the system prompt. Takes precedence over prompt_file.'
     required: false
@@ -65,6 +69,7 @@ runs:
     - --ai_model=${{ inputs.AI_MODEL }}
     - --ai_max_tokens=${{ inputs.ai_max_tokens }}
     - --max_diff_bytes=${{ inputs.max_diff_bytes }}
+    - --chunk_threshold_bytes=${{ inputs.chunk_threshold_bytes }}
     - --prompt_override=${{ inputs.prompt_override }}
     - --prompt_file=${{ inputs.prompt_file }}
     - --review_mode=${{ inputs.review_mode }}

--- a/src/chunked.sh
+++ b/src/chunked.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+# Helpers for splitting an oversized diff into per-file chunks and running
+# the AI reviewer over each chunk. The aggregated response keeps the same
+# shape the rest of the action expects (a single string), so downstream
+# comment / review posting is unchanged.
+
+# chunked::split_by_file reads a unified diff on stdin and prints chunks
+# separated by a literal "<<<ROBIN_CHUNK_BOUNDARY>>>" sentinel on its own
+# line. NUL would be cleaner but busybox/BSD awk drop embedded NULs in
+# printf, and Alpine's runtime image uses busybox.
+chunked::split_by_file() {
+  awk '
+    BEGIN {
+      buf = ""
+      first = 1
+    }
+    /^diff --git a\// {
+      if (!first) {
+        print buf
+        print "<<<ROBIN_CHUNK_BOUNDARY>>>"
+      }
+      buf = $0
+      first = 0
+      next
+    }
+    {
+      buf = buf "\n" $0
+    }
+    END {
+      if (!first) {
+        print buf
+      }
+    }
+  '
+}
+
+# chunked::file_path_of_chunk extracts `path/to/file` from the
+# `diff --git a/<path> b/<path>` header of a chunk for use in the
+# aggregated comment body.
+chunked::file_path_of_chunk() {
+  local -r chunk="$1"
+  # First line is `diff --git a/<path> b/<path>`; pull the `b/` side.
+  awk 'NR==1 { sub(/.* b\//, ""); print; exit }' <<< "$chunk"
+}
+
+# chunked::review iterates over per-file chunks and concatenates the AI
+# responses into a single Markdown body. Each chunk is submitted with the
+# existing ai::prompt_model so prompt resolution / model selection / retries
+# all keep working.
+#
+# Args:
+#   $1 the full diff
+chunked::review() {
+  local -r diff="$1"
+  local aggregated=""
+  local chunk_count=0
+
+  # Slurp the sentinel-delimited output, then split it back in shell. Using
+  # mapfile / readarray is unfortunately awkward when the records contain
+  # newlines, so we do it with a tmp variable and parameter expansion.
+  local raw
+  raw="$(printf '%s' "$diff" | chunked::split_by_file)"
+  if [[ -z "$raw" ]]; then
+    # No `diff --git a/` headers found - just hand off to the single-shot
+    # reviewer.
+    ai::prompt_model "$diff"
+    return
+  fi
+
+  local sentinel="<<<ROBIN_CHUNK_BOUNDARY>>>"
+  while [[ -n "$raw" ]]; do
+    local chunk rest
+    if [[ "$raw" == *"$sentinel"* ]]; then
+      chunk="${raw%%"$sentinel"*}"
+      rest="${raw#*"$sentinel"}"
+      # Trim the trailing newline that `print` added before the sentinel.
+      chunk="${chunk%$'\n'}"
+    else
+      chunk="$raw"
+      rest=""
+    fi
+    raw="$rest"
+
+    chunk_count=$((chunk_count + 1))
+    local path response
+    path="$(chunked::file_path_of_chunk "$chunk")"
+    [[ -z "$path" ]] && path="(unknown file)"
+
+    utils::log_info "Reviewing chunk $chunk_count: $path"
+    response="$(ai::prompt_model "$chunk")"
+
+    if [[ -z "$response" ]]; then
+      response="_(no feedback returned)_"
+    fi
+
+    aggregated+="## \`${path}\`"$'\n\n'
+    aggregated+="$response"$'\n\n'
+
+    # Strip the leading newline that `print` may have left at the front of
+    # the next chunk.
+    raw="${raw#$'\n'}"
+    [[ -z "$raw" ]] && break
+  done
+
+  printf '%s' "$aggregated"
+}

--- a/src/main.sh
+++ b/src/main.sh
@@ -10,13 +10,14 @@ source "$HOME_DIR/src/github.sh"
 source "$HOME_DIR/src/gitlab.sh"
 source "$HOME_DIR/src/ai.sh"
 source "$HOME_DIR/src/review.sh"
+source "$HOME_DIR/src/chunked.sh"
 
 ##? Auto-reviews a Pull Request
 ##?
 ##? Usage:
-##?   main.sh [--git_provider=<provider>] [--git_token=<token>] [--github_token=<token>] [--ai_provider=<provider>] [--ai_api_key=<key>] [--ai_model=<model>] [--ai_max_tokens=<n>] [--max_diff_bytes=<n>] [--prompt_override=<text>] [--prompt_file=<path>] [--review_mode=<mode>] [--github_api_url=<url>] [--files_to_ignore=<files>] [--open_ai_api_key=<token>] [--gpt_model_name=<name>]
+##?   main.sh [--git_provider=<provider>] [--git_token=<token>] [--github_token=<token>] [--ai_provider=<provider>] [--ai_api_key=<key>] [--ai_model=<model>] [--ai_max_tokens=<n>] [--max_diff_bytes=<n>] [--chunk_threshold_bytes=<n>] [--prompt_override=<text>] [--prompt_file=<path>] [--review_mode=<mode>] [--github_api_url=<url>] [--files_to_ignore=<files>] [--open_ai_api_key=<token>] [--gpt_model_name=<name>]
 main() {
-  local git_provider git_token github_token ai_provider ai_api_key ai_model ai_max_tokens max_diff_bytes prompt_override prompt_file review_mode github_api_url files_to_ignore
+  local git_provider git_token github_token ai_provider ai_api_key ai_model ai_max_tokens max_diff_bytes chunk_threshold_bytes prompt_override prompt_file review_mode github_api_url files_to_ignore
   local open_ai_api_key gpt_model_name  # Legacy parameters
 
   eval "$(docpars -h "$(grep "^##?" "${BASH_SOURCE[0]}" | cut -c 5-)" : "$@")"
@@ -121,6 +122,13 @@ main() {
   local diff_byte_cap
   diff_byte_cap="${max_diff_bytes:-200000}"
 
+  # When the diff exceeds chunk_threshold_bytes we split per-file and run
+  # the AI over each chunk in turn, concatenating the results. Disabled in
+  # review mode because we'd need to merge structured JSON from several
+  # responses (future work). 0 disables chunking entirely.
+  local chunk_cap
+  chunk_cap="${chunk_threshold_bytes:-100000}"
+
   local review_number commit_diff ai_response
   case "$git_provider" in
     "github")
@@ -147,12 +155,22 @@ main() {
 
   local diff_size
   diff_size=${#commit_diff}
-  if (( diff_size > diff_byte_cap )); then
-    utils::log_info "Diff is ${diff_size} bytes; truncating to ${diff_byte_cap} bytes for the model."
-    commit_diff="[Diff truncated to ${diff_byte_cap} of ${diff_size} bytes for model context limits.]"$'\n\n'"${commit_diff:0:$diff_byte_cap}"
+
+  local should_chunk=0
+  if (( chunk_cap > 0 )) && (( diff_size > chunk_cap )) && [[ "$review_mode" != "review" ]]; then
+    should_chunk=1
   fi
 
-  ai_response=$(ai::prompt_model "$commit_diff")
+  if (( should_chunk )); then
+    utils::log_info "Diff is ${diff_size} bytes; running per-file chunked review (threshold ${chunk_cap})."
+    ai_response=$(chunked::review "$commit_diff")
+  else
+    if (( diff_size > diff_byte_cap )); then
+      utils::log_info "Diff is ${diff_size} bytes; truncating to ${diff_byte_cap} bytes for the model."
+      commit_diff="[Diff truncated to ${diff_byte_cap} of ${diff_size} bytes for model context limits.]"$'\n\n'"${commit_diff:0:$diff_byte_cap}"
+    fi
+    ai_response=$(ai::prompt_model "$commit_diff")
+  fi
 
   if [[ -z "$ai_response" ]]; then
     utils::log_error "AI response was empty. Double check your API key and billing details."

--- a/tests/chunked.bats
+++ b/tests/chunked.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+
+setup() {
+  load test_helper
+  load_sources
+  # shellcheck source=../src/chunked.sh
+  source "$HOME_DIR/src/chunked.sh"
+}
+
+THREE_FILE_DIFF='diff --git a/src/foo.py b/src/foo.py
+--- a/src/foo.py
++++ b/src/foo.py
+@@ -1 +1,2 @@
+ ctx
++added foo
+diff --git a/src/bar.py b/src/bar.py
+--- a/src/bar.py
++++ b/src/bar.py
+@@ -1 +1,2 @@
+ ctx
++added bar
+diff --git a/src/baz/qux.py b/src/baz/qux.py
+--- a/src/baz/qux.py
++++ b/src/baz/qux.py
+@@ -1 +1,2 @@
+ ctx
++added qux
+'
+
+@test "split_by_file: emits one chunk per file separated by sentinel" {
+  output="$(printf '%s' "$THREE_FILE_DIFF" | chunked::split_by_file)"
+  # Three files -> two boundary sentinels.
+  count=$(grep -c '^<<<ROBIN_CHUNK_BOUNDARY>>>$' <<< "$output" || true)
+  [ "$count" -eq 2 ]
+}
+
+@test "split_by_file: each chunk starts with a diff header" {
+  output="$(printf '%s' "$THREE_FILE_DIFF" | chunked::split_by_file)"
+  # First and post-sentinel lines must begin with `diff --git a/`.
+  awk '
+    NR == 1 && !/^diff --git a\// { exit 1 }
+    prev_was_sentinel && !/^diff --git a\// { exit 1 }
+    { prev_was_sentinel = ($0 == "<<<ROBIN_CHUNK_BOUNDARY>>>") }
+  ' <<< "$output"
+}
+
+@test "file_path_of_chunk: extracts the b-side path" {
+  chunk='diff --git a/src/baz/qux.py b/src/baz/qux.py
+--- a/src/baz/qux.py
++++ b/src/baz/qux.py
+@@ -1 +1,2 @@
+ ctx
++x
+'
+  result="$(chunked::file_path_of_chunk "$chunk")"
+  [ "$result" = "src/baz/qux.py" ]
+}
+
+@test "review: invokes ai::prompt_model once per file and aggregates" {
+  # Use a file-based counter because the stub gets called inside $()
+  # subshells, so a regular shell variable wouldn't survive across calls.
+  counter_file="$(mktemp)"
+  echo 0 > "$counter_file"
+  export COUNTER_FILE="$counter_file"
+
+  ai::prompt_model() {
+    local n
+    n=$(< "$COUNTER_FILE")
+    n=$((n+1))
+    echo "$n" > "$COUNTER_FILE"
+    echo "REVIEW_$n"
+  }
+
+  result="$(chunked::review "$THREE_FILE_DIFF")"
+  [[ "$result" == *"## \`src/foo.py\`"* ]]
+  [[ "$result" == *"## \`src/bar.py\`"* ]]
+  [[ "$result" == *"## \`src/baz/qux.py\`"* ]]
+  [[ "$result" == *"REVIEW_1"* ]]
+  [[ "$result" == *"REVIEW_2"* ]]
+  [[ "$result" == *"REVIEW_3"* ]]
+
+  total="$(< "$counter_file")"
+  [ "$total" -eq 3 ]
+  rm -f "$counter_file"
+}
+
+@test "review: substitutes a placeholder when the AI returns nothing" {
+  ai::prompt_model() { :; }  # echoes nothing
+  result="$(chunked::review "$THREE_FILE_DIFF")"
+  [[ "$result" == *"_(no feedback returned)_"* ]]
+}
+
+@test "review: falls through to single-shot when there are no diff headers" {
+  ai::prompt_model() { echo "SINGLE_SHOT"; }
+  result="$(chunked::review "this is not a diff at all")"
+  [ "$result" = "SINGLE_SHOT" ]
+}


### PR DESCRIPTION
> Final PR in the series — stacked on top of #67 → #66 → #65 → #64 → #63. Review the parents first.

## Summary
- When the combined diff exceeds \`chunk_threshold_bytes\` (default 100KB), the action now splits the diff per file and runs the reviewer model once per chunk, then concatenates the per-file responses into a single Markdown body. Replaces the previous "silent truncation" behaviour on large PRs, which lost all signal from the dropped files.
- Adds \`src/chunked.sh\`:
  - \`chunked::split_by_file\` — awk splitter using a literal sentinel boundary (busybox awk on Alpine drops embedded NULs in printf, so NUL-separated chunks weren't an option).
  - \`chunked::file_path_of_chunk\` — extracts the b-side path for the aggregated comment header.
  - \`chunked::review\` — per-chunk dispatch loop that hands off to the existing \`ai::prompt_model\` so prompt resolution / model selection / retries all stay shared.
- \`main.sh\` decides between single-shot and chunked *before* truncation runs, so chunking actually saves you from losing files when over the cap.
- Chunked review is bypassed in \`review_mode=review\` since merging structured JSON across chunks is a future iteration.

## New input
- \`chunk_threshold_bytes\` (default \`100000\`; \`0\` disables).

## Test plan
- All 41 bats tests pass locally (35 existing + 6 new).
- \`shellcheck -x src/*.sh entrypoint.sh\` clean.
- \`hadolint Dockerfile\` clean.

## Notes for reviewers
- The sentinel approach is cosmetically uglier than NUL but is the only portable option that works with both BSD awk (macOS dev) and busybox awk (Alpine runtime).
- Chunking happens in *sequence*, not in parallel. Parallel was tempting but adds complexity and rate-limit risk; happy to revisit later.
- Each chunk still runs through the full \`ai::prompt_model\` path so retries, token limits, and reasoning-model handling all behave the same.