### PR TITLE
docs: require single-line files_to_ignore to avoid CLI arg breakage

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,5 +11,4 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ignore_file_deletions: 'true'
-          files_to_ignore: |
-            "README.md"
+          files_to_ignore: 'README.md'

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ jobs:
           files_to_ignore: 'README.md assets/* package-lock.json'
 ```
 
+> **Note:** `files_to_ignore` must be written as a single-line, whitespace-separated string (as shown above, e.g. `'README.md assets/* package-lock.json'`). Do not use YAML block scalars (`|` or `>`) — embedded newlines break CLI argument parsing.
+
 ### Using Claude (Anthropic)
 ```yml
 name: Robin AI Reviewer
@@ -190,7 +192,7 @@ For Claude, set `--ai_provider=claude`, pass your Claude API key to `--ai_api_ke
 | `prompt_file` | No | (empty) | Path to a file in the workspace containing the system prompt to use instead of the bundled default. |
 | `review_mode` | No | `comment` | `comment` for one summary PR comment; `review` for inline line-anchored comments via the GitHub Reviews API. |
 | `github_api_url` | No | `https://api.github.com` | GitHub API URL (for enterprise) |
-| `files_to_ignore` | No | (empty) | Files to exclude from review |
+| `files_to_ignore` | No | (empty) | Single-line, whitespace-separated list of files to exclude from review (e.g. `'README.md assets/*'`). Do not use YAML block scalars (`\|` or `>`) — embedded newlines break CLI argument parsing. |
 
 ### Docker and GitLab Arguments
 | Name | Required | Default | Description |
@@ -204,7 +206,7 @@ For Claude, set `--ai_provider=claude`, pass your Claude API key to `--ai_api_ke
 | `max_diff_bytes` | No | `200000` | Soft cap on diff size in bytes; larger diffs are truncated |
 | `prompt_override` | No | (empty) | Inline replacement for the system prompt |
 | `prompt_file` | No | (empty) | Path to a file containing a custom system prompt |
-| `files_to_ignore` | No | (empty) | Files to exclude from review |
+| `files_to_ignore` | No | (empty) | Single-line, whitespace-separated list of files to exclude from review (e.g. `'README.md assets/*'`). Do not use YAML block scalars (`\|` or `>`) — embedded newlines break CLI argument parsing. |
 
 ### Legacy Parameters (Deprecated — removed in v2.0, target 2026-Q3)
 | Name | Required | Default | Description |

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
     required: false
     default: 'https://api.github.com'
   files_to_ignore:
-    description: 'Whitespace separated list of files to ignore'
+    description: 'Single-line, whitespace-separated list of files to ignore (e.g. "README.md assets/* package-lock.json"). Do not use YAML block scalars (| or >); embedded newlines break CLI arg parsing.'
     required: false
     default: ''
   # Legacy support - scheduled for removal in v2.0 (target 2026-Q3)


### PR DESCRIPTION
## Summary
- YAML block scalars (`|` or `>`) for `files_to_ignore` introduce embedded newlines that mangle the `--files_to_ignore=...` CLI argument constructed in `action.yml` and parsed by `src/main.sh`.
- Clarify the single-line constraint everywhere the parameter is documented or exemplified so users don't reach for the multiline form.

## Changes
- **`action.yml`** — expand the `files_to_ignore` input description to explicitly forbid block scalars and show an inline example.
- **`README.md`** — add a `> **Note:**` callout right after the first workflow example (covers all three example blocks below it) and expand both parameter table rows (GitHub Action + Docker/GitLab) with the constraint and an inline example.
- **`.github/workflows/labeler.yml`** — convert the `files_to_ignore: |` block scalar to the inline single-line form for consistency across the repo.

## Notes
- Documentation-only change; no source or test changes.
- The labeler workflow configures the third-party `codelytv/pr-size-labeler` action (not Robin), but is updated for repo-wide consistency.